### PR TITLE
Removed bashism from check_checkrestart.sh

### DIFF
--- a/check_checkrestart.sh
+++ b/check_checkrestart.sh
@@ -94,7 +94,7 @@ package=check_checkrestart
 checkrestart=/usr/sbin/checkrestart
 
 # use sudo for nrpe server running under nagios user
-if [ $EUID -ne 0 ] ; then
+if [ "$(id -u)" -ne 0 ] ; then
 	checkrestart="sudo ${checkrestart}"
 fi
 


### PR DESCRIPTION
The script targets Debian, where dash, the default 'sh' interpreter, raise an error because of `$EUID`. Now it correctly works.
